### PR TITLE
Remove borderRadius prop from MediaDisplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @digitalsilk/block-editor-components
 
+## 0.4.6
+
+### Patch Changes
+
+-   bump
+
 ## 0.4.5
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "0.4.5",
+	"version": "0.4.6",
 	"description": "Digital Silk block editor components library.",
 	"main": "./dist/index.js",
 	"source": "index.js",


### PR DESCRIPTION
The `borderRadius` prop was not being utilized in the `MediaDisplay` component and has been eliminated to simplify the code. This change ensures the component remains focused on essential properties only.